### PR TITLE
Update entrypoint in package.json to target dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-dayparts",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Angular directive for select hours in a week",
   "main": "dist/angular-dayparts.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-dayparts",
   "version": "0.2.8",
   "description": "Angular directive for select hours in a week",
-  "main": "gulpfile.js",
+  "main": "dist/angular-dayparts.js",
   "dependencies": {
     "angular": ">=1.2.0",
     "jquery": ">= 1.9.0",


### PR DESCRIPTION
This changes enables us to simply import this package
```
const dayparts = require('angular-dayparts');
```
rather than needing to include a path to the distributable

```
const dayparts = require('angular-dayparts/dist/angular-dayparts.js');
```